### PR TITLE
Add nomination page

### DIFF
--- a/models/Nominations.js
+++ b/models/Nominations.js
@@ -1,0 +1,53 @@
+var keystone = require('keystone'),
+	Types = keystone.Field.Types;
+
+/**
+ * Nomination Model
+ * ==========
+ */
+
+var Nomination = new keystone.List('Nomination', {
+	nocreate: true,
+	noedit: true
+});
+
+Nomination.add('Award', {
+		award: { type: String, required: true }
+	},
+	'Nomination details', {
+		nominationType: { type: String, required: true, index: true },
+		firstName: { type: String, required: true },
+		lastName: { type: String, required: true },
+		aka: { type: String },
+		reason: { type: String, required: true },
+		nominatedOn: { type: Types.Date, default: Date.now, noedit: true
+	}
+});
+
+
+/**
+ * Schema methods
+ */
+
+Nomination.schema.methods.sendCommitteeNominationEmail = function(callback) {
+	var nomination = this;
+
+	var recipientQuery = keystone.list('Nomination').model.find();
+
+	recipientQuery.exec(function(err) {
+		if (err) return callback(err);
+
+		new keystone.Email('new-award').send({
+			to: 'awards@javascript.org.nz',
+			from: {
+				name: 'JavaScript NZ',
+				email: 'contact@javascript.org.nz'
+			},
+			subject: 'A new nomination for ' + nomination.award,
+			nomination: nomination
+		}, callback);
+	});
+};
+
+Nomination.defaultColumns = 'award, nominationType, firstName, lastName, aka, reason, nominatedOn';
+Nomination.register();

--- a/public/styles/site.less
+++ b/public/styles/site.less
@@ -11,5 +11,18 @@
 	width: 100%;
 }
 
+.awardIcon {
+	text-align: center!important; // Urgh, semantic and it's deep selectors
+}
+
+.awardIcon a {
+	color: rgba(0,0,0,.8);
+}
+
+.awardIcon i {
+	font-size: 4em;
+	padding-top: 20px;
+}
+
 // Add your own site style includes here
 @import "site/layout.less";

--- a/routes/index.js
+++ b/routes/index.js
@@ -46,6 +46,7 @@ exports = module.exports = function(app) {
   app.all('/conduct', routes.views.document);
   app.all('/contact', routes.views.contact);
   app.all('/join', routes.views.join);
+	app.all('/awards', routes.views.awards);
 
 	// NOTE: To protect a route so that only admins can see it, use the requireUser middleware:
 	// app.get('/protected', middleware.requireUser, routes.views.protected);

--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -27,6 +27,7 @@ exports.initLocals = function(req, res, next) {
 	locals.navLinks = [
 		/*{ label: 'Blog',		key: 'blog',		href: '/blog' },
 		{ label: 'Gallery',		key: 'gallery',		href: '/gallery' },*/
+		{ label: 'JSNZ 2017 Awards',		key: 'awards',		href: '/awards' },
     { label: 'Rules',		key: 'rules',		href: '/rules' },
     { label: 'Code of Conduct',		key: 'conduct',		href: '/conduct' },
     { label: 'Contact',		key: 'contact',		href: '/contact' }

--- a/routes/views/awards.js
+++ b/routes/views/awards.js
@@ -16,7 +16,7 @@ exports = module.exports = function(req, res) {
 
 		updater.process(newNomination, {
 			flashErrors: true,
-			fields: 'firstName, lastName, reason',
+			fields: 'nominationType, firstName, lastName, reason',
 			errorMessage: 'There was a problem submitting your nomination:'
 		}, function(err) {
 			if (err) {

--- a/routes/views/awards.js
+++ b/routes/views/awards.js
@@ -1,0 +1,33 @@
+var keystone = require('keystone');
+var Nomination = keystone.list('Nomination');
+
+exports = module.exports = function(req, res) {
+	var view = new keystone.View(req, res),
+		locals = res.locals;
+
+	locals.section = 'awards';
+	locals.formData = req.body || {};
+	locals.validationErrors = {};
+	locals.nominationSubmitted = false;
+
+	view.on('post', { action: 'awards' }, function nominationPost(next) {
+		var newNomination = new Nomination.model(req.body);
+		var updater = newNomination.getUpdateHandler(req);
+
+		updater.process(newNomination, {
+			flashErrors: true,
+			fields: 'firstName, lastName, reason',
+			errorMessage: 'There was a problem submitting your nomination:'
+		}, function(err) {
+			if (err) {
+				locals.validationErrors = err.errors;
+			} else {
+				locals.nominationSubmitted = true;
+				newNomination.sendCommitteeNominationEmail()
+			}
+			next();
+		});
+	});
+
+	view.render('awards');
+};

--- a/templates/emails/new-award.jade
+++ b/templates/emails/new-award.jade
@@ -1,0 +1,16 @@
+extends layouts/base
+
+block content
+	h1 Hi there,
+	p.text-larger A new nomination for #{nomination.award} has been submitted!
+	p &nbsp;
+
+	p.text-large Name:  #{nomination.firstName} #{nomination.lastName} #{nomination.aka && nomination.aka.length ? "(aka, " + nomination.aka + ")" : ""}
+
+	p.text-larger Nomination for: #{nomination.nominationType}
+	p &nbsp;
+
+	p.text-larger Reason: #{nomination.reason}
+
+	p &nbsp;
+	a(href='http://javascript.org.nz/keystone/nominations') View all nominations on the JSNZ site

--- a/templates/includes/footer.html
+++ b/templates/includes/footer.html
@@ -1,5 +1,5 @@
 <footer id="footer">
-	Copyright © 2016 JavaScript NZ Incorporated. {% if not user %}<a class="item" href="/keystone/signin">Admin Sign In</a>{% endif %}
+	Copyright © 2017 JavaScript NZ Incorporated. {% if not user %}<a class="item" href="/keystone/signin">Admin Sign In</a>{% endif %}
 	<br>
 	Header image based on “<a href="https://www.flickr.com/photos/jeffpang/5642694348/">Rotura</a>” by <a href="https://www.flickr.com/photos/jeffpang/">Jeff P</a> / <a href="https://creativecommons.org/licenses/by/2.0/">CC BY 2.0</a>.
 	<br>

--- a/templates/views/awards.html
+++ b/templates/views/awards.html
@@ -19,8 +19,8 @@
 			<p>The JavaScript NZ awards are a community driven award for excellence within the JavaScript NZ world. Award recipients are voted on and presented to each year at nz.js(con);</p>
 			<p>The categories for awards are:</p>
 			<ul>
-				<li>JS Contributor 2016</li>
-				<li>JS Educator 2016</li>
+				<li>JS Contributor 2017</li>
+				<li>JS Educator 2017</li>
 			</ul>
 			<p>Nominations are now open via the form below. Feel free to nominate anybody you think is worthy of the award, including yourself!</p>
 
@@ -31,8 +31,8 @@
 				<div class="field">
 					<label>This nomination is for</label>
 					<select id="nominationType" name="nominationType" class="ui dropdown">
-						<option value="JS Contributor 2016">JS Contributor 2016</option>
-						<option value="JS Educator 2016">JS Educator 2016</option>
+						<option value="Contributor">JS Contributor 2017</option>
+						<option value="Educator">JS Educator 2017</option>
 					</select>
 				</div>
 

--- a/templates/views/awards.html
+++ b/templates/views/awards.html
@@ -30,7 +30,7 @@
 
 				<div class="field">
 					<label>This nomination is for</label>
-					<select id="awardNominationType" name="nominationType" class="ui dropdown">
+					<select id="nominationType" name="nominationType" class="ui dropdown">
 						<option value="JS Contributor 2016">JS Contributor 2016</option>
 						<option value="JS Educator 2016">JS Educator 2016</option>
 					</select>

--- a/templates/views/awards.html
+++ b/templates/views/awards.html
@@ -1,0 +1,72 @@
+{% extends "templates/layouts/default.html" %}
+
+{% block intro %}
+	<div class="ui center aligned header">
+		<h1 class="ui icon header">
+			<i class="trophy icon"></i>
+			<div class="content">JavaScript NZ Awards</div>
+		</h1>
+	</div>
+{% endblock %}
+
+{% block content %}
+	<div class="main container">
+		{% if nominationSubmitted %}
+			<div class="ui form segment">
+				<h3>Thanks! Your vote has been cast.</h3>
+			</div>
+		{% else %}
+			<p>The JavaScript NZ awards are a community driven award for excellence within the JavaScript NZ world. Award recipients are voted on and presented to each year at nz.js(con);</p>
+			<p>The categories for awards are:</p>
+			<ul>
+				<li>JS Contributor 2016</li>
+				<li>JS Educator 2016</li>
+			</ul>
+			<p>Nominations are now open via the form below. Feel free to nominate anybody you think is worthy of the award, including yourself!</p>
+
+			<form method="post" class="ui form segment">
+				<input type="hidden" name="action" value="awards">
+				<input type="hidden" name="award" value="JavaScript NZ 2017">
+
+				<div class="field">
+					<label>This nomination is for</label>
+					<select id="awardNominationType" name="nominationType" class="ui dropdown">
+						<option value="JS Contributor 2016">JS Contributor 2016</option>
+						<option value="JS Educator 2016">JS Educator 2016</option>
+					</select>
+				</div>
+
+				{% set class = ( "error" if validationErrors.firstName else "" ) %}
+				<div class="required field {{ class }}">
+						<label for="awardFirst">First name</label>
+						<input id="awardFirst" type="text" name="firstName" value="{{ formData["firstName"] }}">
+				</div>
+
+				{% set class = ( "error" if validationErrors.lastName else "" ) %}
+				<div class="required field {{ class }}">
+						<label for="awardLast">Last name</label>
+						<input id="awardLast" type="text" name="lastName" value="{{ formData["lastName"] }}">
+				</div>
+
+				<div class="field">
+						<label for="awardAka">Also known as</label>
+						<input id="awardAka" type="text" name="aka" value="{{ formData["aka"] }}">
+				</div>
+
+				{% set class = ( "error" if validationErrors.reason else "" ) %}
+				<div class="required field">
+						<label for="reason">Because: </label>
+						<textarea id="reason" name="reason">{{ formData["reason"] }}</textarea>
+				</div>
+
+				<div class="field">
+					<button class="ui green button" type="submit">Submit your nomination</button>
+				</div>
+			</form>
+		{% endif %}
+	</div>
+{% endblock %}
+
+{% block js %}
+	<script>$('.ui.dropdown').dropdown(); $('.ui.checkbox').checkbox();</script>
+{% endblock %}

--- a/templates/views/index.html
+++ b/templates/views/index.html
@@ -18,6 +18,15 @@
 			<div class="ten wide column">
 				<p><strong>nz.js(con);</strong> New Zealand's first dedicated national JavaScript conference will be held on March 9th & 10th, 2017 at Shed 6 in Wellington. It has an open call for papers, a low cost of entry, and will have a broad variety of JavaScript related topics. If you want to know more you can find all the info you need on <a href="http://conference.javascript.org.nz">the nz.js(con); website</a></p>
 			</div>
+			<div class="six wide column awardIcon">
+				<a href="/awards">
+					<i class="trophy icon"></i>
+				</a>
+			</div>
+			<div class="ten wide column">
+				<p>The <strong>JavaScript NZ awards</strong> are a community driven award for excellence within the JavaScript NZ world. The two categories of awards this year are for JS Contributer and JS Educator. The nomintations will be announced and voted on at this years <a href="http://conference.javascript.org.nz">nz.js(con);</a>.</p>
+<p>If you would like to nominate someone then head on over to the <a href="/awards">JSNZ 2017 awards page</a> and fill in the form.</p>
+			</div>
 		</div>
 	</div>
 {% endblock %}

--- a/updates/0.0.1-admins.js
+++ b/updates/0.0.1-admins.js
@@ -6,7 +6,7 @@
 
 exports.create = {
 	User: [
-		{ 'name.first': 'Admin', 'name.last': 'User', email: 'admin@javascript.org.nz', password: 'admin', isAdmin: true, committeeRole: 'officer' }
+		{ 'name': 'Admin User', email: 'admin@javascript.org.nz', password: 'admin', isAdmin: true, committeeRole: 'officer' }
 	]
 };
 
@@ -25,9 +25,9 @@ var admins = [
 ];
 
 function createAdmin(admin, done) {
-	
+
 	var newAdmin = new User.model(admin);
-	
+
 	newAdmin.isAdmin = true;
 	newAdmin.save(function(err) {
 		if (err) {
@@ -38,7 +38,7 @@ function createAdmin(admin, done) {
 		}
 		done(err);
 	});
-	
+
 }
 
 exports = module.exports = function(done) {


### PR DESCRIPTION
Added:
 - `JSNZ 2017 Awards` to the header
 - `/awards` page
 - a generic `Nomination` model so that we can use some variation of this code again next year
 - an email sender for when a nomination is made
 - a custom admin page for us to look at nominations

Things we should probably do:
 - Add something else to the home page

Here are some screenshots:

<img width="681" alt="screen shot 2017-01-29 at 8 17 56 pm" src="https://cloud.githubusercontent.com/assets/1654201/22402551/40322d2c-e660-11e6-989e-fabfa7e0d2d1.png">
<img width="819" alt="screen shot 2017-01-29 at 8 18 09 pm" src="https://cloud.githubusercontent.com/assets/1654201/22402553/4034d6bc-e660-11e6-959d-e28e18490ff1.png">
<img width="780" alt="screen shot 2017-01-29 at 8 18 19 pm" src="https://cloud.githubusercontent.com/assets/1654201/22402552/403455ac-e660-11e6-9261-fe47f5116869.png">
<img width="839" alt="screen shot 2017-01-29 at 8 18 54 pm" src="https://cloud.githubusercontent.com/assets/1654201/22402555/40387f92-e660-11e6-8dcc-00919635f1fc.png">
<img width="1247" alt="screen shot 2017-01-29 at 8 20 30 pm" src="https://cloud.githubusercontent.com/assets/1654201/22402562/651244ec-e660-11e6-95de-d4e5ecb730f6.png">

