### PR TITLE
Add in recapture + fix chance of spammy email + fix superagent security vulnerability

### DIFF
--- a/models/Enquiry.js
+++ b/models/Enquiry.js
@@ -33,28 +33,16 @@ Enquiry.schema.pre('save', function(next) {
 })
 
 Enquiry.schema.methods.sendNotificationEmail = function(callback) {
-	var enquiry = this;
-
-	var recipientQuery = keystone.list('User').model.find();
-	if (this.enquiryType == 'committee')
-		recipientQuery = recipientQuery.where('committeeRole').ne('');
-	else
-		recipientQuery = recipientQuery.where('committeeRole', this.enquiryType);
-
-	recipientQuery.exec(function(err, recipients) {
-		if (err) return callback(err); 
-
-		new Email('enquiry-notification.pug', emailDefaults).send({
-			enquiry: enquiry
-		}, {
-			to: recipients,
-			from: {
-				name: 'JavaScript NZ',
-				email: 'contact@javascript.org.nz'
-			},
-			subject: 'JavaScript NZ website enquiry for ' + enquiry.enquiryType,
-		}, callback)
-	});
+	new Email('enquiry-notification.pug', emailDefaults).send({
+		enquiry: enquiry
+	}, {
+		to: 'committee@javascript.org.nz',
+		from: {
+			name: 'JavaScript NZ',
+			email: 'contact@javascript.org.nz'
+		},
+		subject: 'JavaScript NZ website enquiry for ' + enquiry.enquiryType,
+	}, callback)
 }
 
 Enquiry.defaultSort = '-createdAt';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1375,11 +1375,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "cookiejar": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.6.tgz",
-      "integrity": "sha1-Cr81atANHFohnYjURRgEbdAmrP4="
-    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -2349,11 +2344,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ=="
-    },
-    "formidable": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
-      "integrity": "sha1-71SRSQ+UM7cF+qdyScmQKa40hVk="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -4486,7 +4476,8 @@
     "mime": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+      "optional": true
     },
     "mime-db": {
       "version": "1.37.0",
@@ -5988,11 +5979,6 @@
       "resolved": "https://registry.npmjs.org/redirect-https/-/redirect-https-1.3.0.tgz",
       "integrity": "sha512-9GzwI/+Cqw3jlSg0CW6TgBQbhiVhkHSDvW8wjgRQ9IK34wtxS71YJiQeazSCSEqbvowHCJuQZgmQFl1xUHKEgg=="
     },
-    "reduce-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
-      "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo="
-    },
     "redux": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
@@ -6841,34 +6827,44 @@
       }
     },
     "superagent": {
-      "version": "1.8.3",
-      "resolved": "http://registry.npmjs.org/superagent/-/superagent-1.8.3.tgz",
-      "integrity": "sha1-K31w/Mhw7aTyph5hndVACbhlR8M=",
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-4.0.0-beta.5.tgz",
+      "integrity": "sha512-v4FTm6kg6zJOfLcot9kCTcWy/wjD/hvtUXWcv0Pd8TlUqxKDctif2rtDPRb4gW6Df9MMXU1BHB+1z5U2VFVsYg==",
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        "cookiejar": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+          "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
         },
-        "extend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+        "debug": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg=="
         },
-        "form-data": {
-          "version": "1.0.0-rc3",
-          "resolved": "http://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-          "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc="
+        "formidable": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+          "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
         },
-        "qs": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
+        "mime": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+          "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "readable-stream": {
-          "version": "1.0.27-1",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-          "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg="
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
+          "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "keystone-email": "^1.1.0",
     "nunjucks": "*",
     "pug": "^2.0.3",
-    "request": "^2.88.0",
     "stripe": "*",
+    "superagent": "^4.0.0-beta.5",
     "underscore": "*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "keystone-email": "^1.1.0",
     "nunjucks": "*",
     "pug": "^2.0.3",
+    "request": "^2.88.0",
     "stripe": "*",
     "underscore": "*"
   },

--- a/routes/views/contact.js
+++ b/routes/views/contact.js
@@ -1,6 +1,6 @@
 var keystone = require('keystone'),
 	Enquiry = keystone.list('Enquiry');
-var request = require('request');
+var superagent = require('superagent');
 
 exports = module.exports = function(req, res) {
 
@@ -35,10 +35,10 @@ exports = module.exports = function(req, res) {
 			 * Validate the recaptcha value that was passed back. Even if it fails we still provide a "success" message to the user. Only difference
 			 * is that the committee doesn't get spammed with rubbish.
 			 */
-			request(url, function (error, response, body) {
-				const parsedBody = JSON.parse(body);
-				console.log('Enquiry received. Recaptcha success result: ' + parsedBody.success); // Log for interests sake. Curious how much spam we stop
-				if (parsedBody.success === true) {
+			superagent.get(url)
+			.end(function (error, response, body) {
+				console.log('Enquiry received. Recaptcha success result: ' + response.body.success); // Log for interests sake. Curious how much spam we stop
+				if (response.body.success === true) {
 					newEnquiry.sendNotificationEmail();
 				}
 				locals.enquirySubmitted = true;

--- a/templates/views/contact.html
+++ b/templates/views/contact.html
@@ -10,12 +10,13 @@
 {% endblock %}
 
 {% block content %}
+	<script src='https://www.google.com/recaptcha/api.js?render=6LdbaXkUAAAAAN8tATysXHZxgwNitR7sisPZhFyz'></script>
 	<div class="main container">
 		<div class="ui form segment">
 		{% if enquirySubmitted %}
 			<h3>Thanks for getting in touch.</h3>
 		{% else %}
-			<form method="post">
+			<form id="contact-form" method="post">
 				<input type="hidden" name="action" value="contact">
 
 				{% set class = ( "error" if validationErrors.name else "" ) %}
@@ -63,5 +64,32 @@
 {% endblock %}
 
 {% block js %}
-<script>$('.ui.dropdown').dropdown();</script>
+<script>
+	var hasSubmitted = false;
+	var submitForm = $('#contact-form');
+	$('.ui.dropdown').dropdown();
+	grecaptcha.ready(function() {
+		// Validate captcha token before sending back to the server
+		submitForm.submit(function(event) {
+			if (hasSubmitted) {
+				return true;
+			}
+			
+			event.preventDefault();
+			grecaptcha.execute('6LdbaXkUAAAAAN8tATysXHZxgwNitR7sisPZhFyz', {
+				action: 'contact'
+			}).then(function(token) {
+				var input = $("<input>")
+						.attr("type", "hidden")
+						.attr("name", "recaptcha").val(token);
+				submitForm.append(input);
+				// Calling .submit fires off this event listener again. Put a flag in here so that it doesn't loop infinitly
+				hasSubmitted = true;
+				submitForm.submit();
+			});
+		});
+});
+		
+
+</script>
 {% endblock %}


### PR DESCRIPTION
## Detail

This start out with just the recapture but ended up with some other things too.

### Recapture

This adds in https://www.google.com/recaptcha/ to reduce the spam we get from the site. I've added the secret key into Heroku already so it should "just work" when we deploy.

I've made it so that even if the recapture fails the user still sees a success message as they don't need to know that the email to us didn't get sent because they are a bot etc.

### Enquiry email address

The site was setup so that different users could have different roles and, depending on the role, the enquiry form would go to different people. I don't know what changed from v2 to v4 but I think I accidentally spammed all users this afternoon when I sent the test email. So I've removed the recipient logic and just hard coded in the committee email address. I can't think of any issue with that off the top of my head.

### Superagent security issue

There was an issue with a version of super agent that's in the package-lock file. I've used superagent as the module to validate the recapture against so, because of that update, the security issue should go away :)